### PR TITLE
fix(fxmanifest): correct dependency for npwd_services

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,34 +4,34 @@ description 'js runtime monkaW'
 authors { "itschip",  "erik-sn", "TasoOneAsia", "kidz", "RockySouthpaw"}
 version '1.6.0'
 client_scripts {
-	"resources/dist/client/client.js",
-	"resources/client/*.lua",
+    "resources/dist/client/client.js",
+    "resources/client/*.lua",
 }
 
 server_script {
-	-- This is a file that lives purely in source code and isn't compiled alongside
-	-- rest of the release. It's used to detect whether a user can read or not.
-	"build-detector.js",
-	"resources/dist/server/server.js",
+    -- This is a file that lives purely in source code and isn't compiled alongside
+    -- rest of the release. It's used to detect whether a user can read or not.
+    "build-detector.js",
+    "resources/dist/server/server.js",
 }
 
 ui_page "resources/html/index.html"
 
 files {
-	"config.json",
-	"resources/html/index.html",
-	"resources/html/**/*",
+    "config.json",
+    "resources/html/index.html",
+    "resources/html/**/*",
 }
 
 dependency {
-	"screenshot-basic",
-	"pma-voice",
+    "screenshot-basic",
+    "pma-voice",
     'npwd_qb_garage',
     'npwd_qb_mail',
-	'npwd_qb_racing',
-	'npwd_crypto',
-	'npwd_qb_banking',
-    'npwd_qb_services',
-	'npwd_qb_housing',
-	'qb-npwd',
+    'npwd_qb_racing',
+    'npwd_crypto',
+    'npwd_qb_banking',
+    'npwd_services',
+    'npwd_qb_housing',
+    'qb-npwd',
 }


### PR DESCRIPTION
This PR corrects the dependency in the `fxmanifest` for `npwd_services`.
Also fixes some whitespace indentation.